### PR TITLE
fix: align resend_command ROS param with launch files

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -59,13 +59,14 @@ namespace uosm
 				declare_parameter("height", rclcpp::ParameterValue(1.00f));
 				declare_parameter("mission_objective", rclcpp::ParameterValue(""));
 				declare_parameter("introspector_object", rclcpp::ParameterValue("Aruco Marker"));
-				declare_parameter("resend_commnad", rclcpp::ParameterValue(true));
+				// Canonical name matches launch files (was misspelled resend_commnad).
+				declare_parameter("resend_command", rclcpp::ParameterValue(true));
 				declare_parameter("resend_size", rclcpp::ParameterValue(10));
 
 				height_ = get_parameter("height").as_double();
 				mission_objective_ = get_parameter("mission_objective").as_string();
 				introspector_object_ = get_parameter("introspector_object").as_string();
-				resend_command_ = get_parameter("resend_commnad").as_bool();
+				resend_command_ = get_parameter("resend_command").as_bool();
 				resend_size_ = get_parameter("resend_size").as_int();
 
 				// Publishers & Subscribers setup

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -60,13 +60,14 @@ namespace uosm
 				declare_parameter("height", rclcpp::ParameterValue(1.00f));
 				declare_parameter("mission_objective", rclcpp::ParameterValue(""));
 				declare_parameter("introspector_object", rclcpp::ParameterValue("Aruco Marker"));
-				declare_parameter("resend_commnad", rclcpp::ParameterValue(true));
+				// Canonical name matches launch files (was misspelled resend_commnad).
+				declare_parameter("resend_command", rclcpp::ParameterValue(true));
 				declare_parameter("resend_size", rclcpp::ParameterValue(10));
 
 				height_ = get_parameter("height").as_double();
 				mission_objective_ = get_parameter("mission_objective").as_string();
 				introspector_object_ = get_parameter("introspector_object").as_string();
-				resend_command_ = get_parameter("resend_commnad").as_bool();
+				resend_command_ = get_parameter("resend_command").as_bool();
 				resend_size_ = get_parameter("resend_size").as_int();
 
 				// Publishers & Subscribers setup


### PR DESCRIPTION
## Summary
Launch files for both agent control nodes set the parameter `resend_command`, but `px4_agent_nav_node` and `px4_agent_search_approach_node` declared and read the misspelled name `resend_commnad`. That meant launch overrides never applied and operators could not disable resend via launch parameters.

## Motivation
- Keeps ROS parameter names consistent with launch files and member `resend_command_`.
- No change to arming, offboard mode, altitude/NED height, or Move/Turn parsing.

## Verification
```bash
grep -R "resend_commnad" src/px4_agent_control && exit 1 || echo OK_no_typo
grep -n "resend_command" src/px4_agent_control/src/*.cpp src/px4_agent_control/launch/*.py
```


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
