### PR TITLE
fix: clamp resend_size and document ROS parameters

### DIFF
--- a/src/px4_agent_control/README.md
+++ b/src/px4_agent_control/README.md
@@ -1,5 +1,7 @@
 # px4_agent_control
 
+Agentic PX4 offboard control nodes that bridge VLN / introspector agent text topics to PX4 trajectory setpoints.
+
 ```
 colcon build
 source install/setup.bash
@@ -14,3 +16,17 @@ ros2 launch px4_agent_control px4_agent_nav.launch.py
 ```
 ros2 launch px4_agent_control px4_agent_search_approach.launch.py
 ```
+
+## ROS parameters
+
+Both `px4_agent_nav_node` and `px4_agent_search_approach_node` accept:
+
+| Parameter | Type | Default | Notes |
+|-----------|------|---------|--------|
+| `height` | double | `1.0` | Hold altitude magnitude (m); published NED z is `-abs(height)` |
+| `mission_objective` | string | `""` | Goal / obstacle text for the VLN query (see launch examples) |
+| `introspector_object` | string | `"Aruco Marker"` | Object name for the introspector prompt |
+| `resend_command` | bool | `true` | When true, include recent VLN history in the next query. **Note:** nodes currently declare/get this under the misspelled key `resend_commnad` (typo); launch files already pass `resend_command` — align keys so overrides apply (tracked separately). |
+| `resend_size` | int | `10` | Max VLN history lines included when resending. **Clamped to `[1, 100]`** after load (values outside log a warning and are adjusted). |
+
+Launch files under `launch/` set sensible demo defaults for the fields above.

--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -67,6 +67,17 @@ namespace uosm
 				introspector_object_ = get_parameter("introspector_object").as_string();
 				resend_command_ = get_parameter("resend_commnad").as_bool();
 				resend_size_ = get_parameter("resend_size").as_int();
+				// Bound VLN history used when resending prompts (avoid unbounded growth / huge queries)
+				if (resend_size_ < 1)
+				{
+					RCLCPP_WARN(get_logger(), "resend_size=%d is < 1; clamping to 1", resend_size_);
+					resend_size_ = 1;
+				}
+				else if (resend_size_ > 100)
+				{
+					RCLCPP_WARN(get_logger(), "resend_size=%d is > 100; clamping to 100", resend_size_);
+					resend_size_ = 100;
+				}
 
 				// Publishers & Subscribers setup
 				const auto qos_profile = rclcpp::QoS(10)

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -68,6 +68,17 @@ namespace uosm
 				introspector_object_ = get_parameter("introspector_object").as_string();
 				resend_command_ = get_parameter("resend_commnad").as_bool();
 				resend_size_ = get_parameter("resend_size").as_int();
+				// Bound VLN history used when resending prompts (avoid unbounded growth / huge queries)
+				if (resend_size_ < 1)
+				{
+					RCLCPP_WARN(get_logger(), "resend_size=%d is < 1; clamping to 1", resend_size_);
+					resend_size_ = 1;
+				}
+				else if (resend_size_ > 100)
+				{
+					RCLCPP_WARN(get_logger(), "resend_size=%d is > 100; clamping to 100", resend_size_);
+					resend_size_ = 100;
+				}
 
 				// Publishers & Subscribers setup
 				const auto qos_profile = rclcpp::QoS(10)


### PR DESCRIPTION
## Summary
- Clamp `resend_size` to `[1, 100]` after load in both control nodes (WARN + adjust)
- Document ROS parameters in `src/px4_agent_control/README.md`
- Call out existing `resend_commnad` misspelling vs launch `resend_command` (does not change that key; see open #2)

## Motivation
Unbounded history size in resend prompts can explode context when operators set huge `resend_size`. Docs help map launch params to node behavior on this dormant paper workspace.

## Verification
- Parameter load paths include clamps in nav + search_approach
- Spec: specs/ros2-px4-agent-ws/2026-07-14-2.md

## Notes
Orthogonal to #2 param typo rename and #4 Move/Turn parse hardening.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
