### PR TITLE
fix: harden mission goal/obstacle coordinate parsing

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -49,6 +49,36 @@ namespace uosm
 			}
 		}
 
+		// Safe float from mission text (regex captures). Returns false if throw/non-finite/out of range.
+		static bool tryParseMissionCoord(const std::string &token, float *out, float max_abs = 500.0f)
+		{
+			if (!out)
+			{
+				return false;
+			}
+			try
+			{
+				size_t idx = 0;
+				float v = std::stof(token, &idx);
+				if (idx == 0 || !std::isfinite(v))
+				{
+					return false;
+				}
+				if (std::fabs(v) > max_abs)
+				{
+					v = std::copysign(max_abs, v);
+				}
+				*out = v;
+				return true;
+			}
+			catch (const std::exception &)
+			{
+				return false;
+			}
+		}
+
+
+
 		class PX4AgentControl : public rclcpp::Node
 		{
 		public:
@@ -446,8 +476,19 @@ namespace uosm
 				std::smatch matches;
 				if (std::regex_search(mission_objective_, matches, goal_regex) && matches.size() == 3)
 				{
-					goal_x_ = std::stof(matches[1].str());
-					goal_y_ = std::stof(matches[2].str());
+					float gx = 0.0f;
+					float gy = 0.0f;
+					if (!tryParseMissionCoord(matches[1].str(), &gx) || !tryParseMissionCoord(matches[2].str(), &gy))
+					{
+						RCLCPP_ERROR(get_logger(), "Failed to extract goal coordinates from mission objective!");
+						goal_x_ = 0.0f;
+						goal_y_ = 0.0f;
+					}
+					else
+					{
+						goal_x_ = gx;
+						goal_y_ = gy;
+					}
 				}
 				else
 				{
@@ -462,8 +503,13 @@ namespace uosm
 				for (auto it = std::sregex_iterator(mission_objective_.begin(), mission_objective_.end(), obs_regex);
 					 it != std::sregex_iterator(); ++it)
 				{
-					float ox = std::stof((*it)[1].str());
-					float oy = std::stof((*it)[2].str());
+					float ox = 0.0f;
+					float oy = 0.0f;
+					if (!tryParseMissionCoord((*it)[1].str(), &ox) || !tryParseMissionCoord((*it)[2].str(), &oy))
+					{
+						RCLCPP_WARN(get_logger(), "Skipping non-finite/out-of-range obstacle coordinate pair");
+						continue;
+					}
 					if (ox == goal_x_ && oy == goal_y_) continue;
 					obstacles_.emplace_back(ox, oy);
 				}

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -50,6 +50,36 @@ namespace uosm
 			}
 		}
 
+		// Safe float from mission text (regex captures). Returns false if throw/non-finite/out of range.
+		static bool tryParseMissionCoord(const std::string &token, float *out, float max_abs = 500.0f)
+		{
+			if (!out)
+			{
+				return false;
+			}
+			try
+			{
+				size_t idx = 0;
+				float v = std::stof(token, &idx);
+				if (idx == 0 || !std::isfinite(v))
+				{
+					return false;
+				}
+				if (std::fabs(v) > max_abs)
+				{
+					v = std::copysign(max_abs, v);
+				}
+				*out = v;
+				return true;
+			}
+			catch (const std::exception &)
+			{
+				return false;
+			}
+		}
+
+
+
 		class PX4AgentControl : public rclcpp::Node
 		{
 		public:
@@ -108,8 +138,18 @@ namespace uosm
 				std::smatch match;
 				if (std::regex_search(mission_objective_, match, coords_pattern) && match.size() == 3)
 				{
-					goal_x = std::stof(match[1].str());
-					goal_y = std::stof(match[2].str());
+					float gx = 0.0f;
+					float gy = 0.0f;
+					if (!tryParseMissionCoord(match[1].str(), &gx) || !tryParseMissionCoord(match[2].str(), &gy))
+					{
+						RCLCPP_WARN(get_logger(), "Failed to parse goal coordinates from mission objective");
+						goal_x = 0.0f;
+						goal_y = 0.0f;
+						is_init_ = false;
+						return;
+					}
+					goal_x = gx;
+					goal_y = gy;
 					RCLCPP_INFO(get_logger(), "Goal coordinates parsed: (%.2f, %.2f)", goal_x, goal_y);
 				}
 				else


### PR DESCRIPTION
## Summary
- Mission Goal and obstacle (x,y) parsing used bare std::stof (can throw and abort node).
- Add tryParseMissionCoord: finite + soft |coord|<=500m in nav and search-approach.

## Spec
specs/ros2-px4-agent-ws/2026-07-15-1.md

## Test plan
- [x] Diff review
- [ ] colcon build px4_agent_control
- Manual: bad Goal text ERROR without process abort

## Safety
No arm/geofence changes. Orthogonal to open #2-#5.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
