### PR TITLE
fix: clamp height parameter to safe positive range

### DIFF
--- a/src/px4_agent_control/README.md
+++ b/src/px4_agent_control/README.md
@@ -14,3 +14,14 @@ ros2 launch px4_agent_control px4_agent_nav.launch.py
 ```
 ros2 launch px4_agent_control px4_agent_search_approach.launch.py
 ```
+
+## Parameters
+
+| Name | Default | Notes |
+|------|---------|--------|
+| `height` | `1.0` | Hold altitude (m). Non-finite or `<= 0` → **1.0**; values **> 120** soft-clamped with a warning. Published NED z uses `-abs(height)`. |
+| `mission_objective` | `""` | Goal / obstacle text for VLN |
+| `introspector_object` | `"Aruco Marker"` | Introspector prompt object name |
+| `resend_commnad` | `true` | Typo vs launch `resend_command` — param-alignment tracked separately |
+| `resend_size` | `10` | VLN history lines when resending |
+

--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -63,6 +63,18 @@ namespace uosm
 				declare_parameter("resend_size", rclcpp::ParameterValue(10));
 
 				height_ = get_parameter("height").as_double();
+				// Fail-closed positive hold altitude (meters, magnitude used with NED -abs)
+				if (!std::isfinite(height_) || height_ <= 0.0)
+				{
+					RCLCPP_WARN(get_logger(), "height=%g is non-finite or <= 0; defaulting to 1.0 m", height_);
+					height_ = 1.0;
+				}
+				else if (height_ > 120.0)
+				{
+					RCLCPP_WARN(get_logger(), "height=%g m exceeds 120 m soft cap; clamping", height_);
+					height_ = 120.0;
+				}
+
 				mission_objective_ = get_parameter("mission_objective").as_string();
 				introspector_object_ = get_parameter("introspector_object").as_string();
 				resend_command_ = get_parameter("resend_commnad").as_bool();

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -64,6 +64,18 @@ namespace uosm
 				declare_parameter("resend_size", rclcpp::ParameterValue(10));
 
 				height_ = get_parameter("height").as_double();
+				// Fail-closed positive hold altitude (meters, magnitude used with NED -abs)
+				if (!std::isfinite(height_) || height_ <= 0.0)
+				{
+					RCLCPP_WARN(get_logger(), "height=%g is non-finite or <= 0; defaulting to 1.0 m", height_);
+					height_ = 1.0;
+				}
+				else if (height_ > 120.0)
+				{
+					RCLCPP_WARN(get_logger(), "height=%g m exceeds 120 m soft cap; clamping", height_);
+					height_ = 120.0;
+				}
+
 				mission_objective_ = get_parameter("mission_objective").as_string();
 				introspector_object_ = get_parameter("introspector_object").as_string();
 				resend_command_ = get_parameter("resend_commnad").as_bool();


### PR DESCRIPTION
## Summary
- height drives NED hold via -abs(height). 0/negative/NaN/huge values are unsafe.
- Normalize: non-finite or <=0 → 1.0 m; >120 soft clamp + WARN on both nodes.
- Document in package README.

## Spec
specs/ros2-px4-agent-ws/2026-07-15-2.md

## Test plan
- [x] Clamp presence on both nodes
- [ ] colcon build px4_agent_control

## Safety
No arm/geofence weaken. Independent of #2-#6.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
