### PR TITLE
fix: use abs heading error before FLYING→INTROSPECTION

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -619,7 +619,7 @@ int main(int argc, char *argv[])
 					const double dist = uosm::px4::computeEuclideanDistance(node->traj_, node->vehicle_lp_);
 					const double heading_diff = node->traj_.yaw - node->vehicle_lp_.heading;
 
-					if (dist < uosm::px4::FLYING_TOLERANCE && heading_diff < uosm::px4::HEADING_TOLERANCE)
+					if (dist < uosm::px4::FLYING_TOLERANCE && std::abs(heading_diff) < uosm::px4::HEADING_TOLERANCE)
 					{
 						// once vehicle reached traj location, start introspection
 						node->is_vln_updated_ = false;


### PR DESCRIPTION
## Summary
- In `px4_agent_nav_node`, FLYING→INTROSPECTION required `heading_diff < HEADING_TOLERANCE` without `std::abs`.
- Negative yaw error blocked mission progress even when within magnitude tolerance.
- Aligns with `px4_agent_search_approach_node`, which already uses `std::abs(heading_diff)`.

## Test plan
- [x] Code review parity vs search_approach FLYING gate
- [ ] SITL: confirm INTROSPECTION after waypoint with negative residual yaw

AI-assisted; human-reviewed. No geofence/arm policy change.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
