### PR TITLE
fix: detect land complete via arming/disarm reason

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -672,7 +672,10 @@ int main(int argc, char *argv[])
 					double landing_lon = home_lon + lon_offset * uosm::px4::RAD2DEG;
 					node->request_landing(landing_lat, landing_lon, home_alt);
 				}
-				if (nav_state == px4_msgs::msg::VehicleStatus::ARM_DISARM_REASON_AUTO_DISARM_LAND)
+				// ARM_DISARM_REASON_* is not a nav_state: use arming + latest_disarming_reason
+				if (arming_state == px4_msgs::msg::VehicleStatus::ARMING_STATE_DISARMED ||
+					node->vehicle_status_.latest_disarming_reason ==
+						px4_msgs::msg::VehicleStatus::ARM_DISARM_REASON_AUTO_DISARM_LAND)
 				{
 					node->switch_to_manual_mode();
 					state_ = STATE::DISARMED;

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -657,7 +657,10 @@ int main(int argc, char *argv[])
 					double landing_lon = home_lon + lon_offset * uosm::px4::RAD2DEG;
 					node->request_landing(landing_lat, landing_lon, home_alt);
 				}
-				if (nav_state == px4_msgs::msg::VehicleStatus::ARM_DISARM_REASON_AUTO_DISARM_LAND)
+				// ARM_DISARM_REASON_* is not a nav_state: use arming + latest_disarming_reason
+				if (arming_state == px4_msgs::msg::VehicleStatus::ARMING_STATE_DISARMED ||
+					node->vehicle_status_.latest_disarming_reason ==
+						px4_msgs::msg::VehicleStatus::ARM_DISARM_REASON_AUTO_DISARM_LAND)
 				{
 					node->switch_to_manual_mode();
 					state_ = STATE::DISARMED;


### PR DESCRIPTION
## Summary
- Both agent nodes compared `nav_state` to `ARM_DISARM_REASON_AUTO_DISARM_LAND` (value 7).
- That enum is a **disarm reason**, not a navigation mode (`NAVIGATION_STATE_*`), so LANDING rarely (ever) transitioned to DISARMED.
- Exit now when `arming_state == ARMING_STATE_DISARMED` **or** `latest_disarming_reason == ARM_DISARM_REASON_AUTO_DISARM_LAND`, then switch to manual as before.

## Test plan
- [x] Confirmed VehicleStatus.msg field/enum separation
- [x] Same fix in nav + search_approach
- [ ] SITL land → auto-disarm → node returns DISARMED / exits cleanly

AI-assisted; human-reviewed. Does not change land command issuance or weaken safety.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
