### PR TITLE
fix: do not clobber LANDING after mission-done introspection

### DIFF
--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -622,21 +622,25 @@ int main(int argc, char *argv[])
 			case STATE::INTROSPECTION:
 			{
 				// RCLCPP_WARN(node->get_logger(), "STATE::INTROSPECTION");
-				if (node->is_mission_done_)
-				{
-					// mission completed, switch to auto land
-					is_done_ = true;
-					state_ = STATE::LANDING;
-				}
-	
+				// Require if/else: when introspector answers "Yes", both flags are true.
+				// A second independent if would reset state_ from LANDING back to FLYING.
 				if (node->is_introspection_updated_)
 				{
-					// mission not completed, keep flying with vln cmds
-					node->is_introspection_updated_ = false;
-					node->is_vln_updated_ = false;
-					node->publish_vln_query();
-					state_ = STATE::FLYING;
-					// TODO: add INTROSPECTION timeout
+					if (node->is_mission_done_)
+					{
+						// mission completed, switch to auto land
+						is_done_ = true;
+						state_ = STATE::LANDING;
+					}
+					else
+					{
+						// mission not completed, keep flying with vln cmds
+						node->is_introspection_updated_ = false;
+						node->is_vln_updated_ = false;
+						node->publish_vln_query();
+						state_ = STATE::FLYING;
+						// TODO: add INTROSPECTION timeout
+					}
 				}
 				break;
 			}


### PR DESCRIPTION
## Summary
On `px4_agent_search_approach_node`, INTROSPECTION used two independent `if`s. When the introspector answers `"Yes"`, both `is_mission_done_` and `is_introspection_updated_` are typically true, so the code set `LANDING` and then immediately overwrote `state_` back to `FLYING`. Landing never stuck.

This matches the nav node: one gate on `is_introspection_updated_`, then if/else for mission-done vs continue.

## Change
- `src/px4_agent_control/src/px4_agent_search_approach_node.cpp` only

## Test plan
- [ ] Code review: Yes path reaches LANDING only
- [ ] Non-Yes path still republishes VLN and returns to FLYING
- [ ] No arm/geofence/param renames

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
