### PR TITLE
fix: clamp Move distance and Turn angle from VLN text

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -16,6 +16,7 @@
 #include <chrono>
 #include <functional>
 #include <string>
+#include <algorithm>
 #include <regex>
 
 using namespace std::chrono;
@@ -30,6 +31,8 @@ namespace uosm
 		constexpr float HOVERING_TOLERANCE(0.1f); // based on short term vio drift
 		constexpr float FLYING_TOLERANCE(0.1f);	  // based on short term vio drift
 		constexpr float HEADING_TOLERANCE(0.1f);  //  0.1 rad ~= 5.73 deg
+		constexpr float MAX_TURN_DEG(180.0f);
+		constexpr float MAX_MOVE_M(5.0f);  // per-command setpoint bound
 		constexpr float RAD2DEG(180 / M_PI);
 		constexpr float DEG2RAD(M_PI / 180);
 		constexpr double EARTH_RADIUS(6378137.0); // Earth radius in meters at equator
@@ -201,6 +204,7 @@ namespace uosm
 					{
 						// Extract angle in degrees
 						float angle_deg = std::stof(line.substr(5, line.find(')') - 5));
+						angle_deg = std::clamp(angle_deg, -MAX_TURN_DEG, MAX_TURN_DEG);
 						// Convert to radians and update heading
 						float angle_rad = angle_deg * DEG2RAD;
 						current_heading += angle_rad;
@@ -215,6 +219,8 @@ namespace uosm
 					{
 						// Extract distance in meters
 						float distance = std::stof(line.substr(5, line.find(')') - 5));
+
+						distance = std::clamp(distance, -MAX_MOVE_M, MAX_MOVE_M);
 
 						// Update position based on current heading and distance
 						current_x += distance * cos(current_heading);

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -16,6 +16,7 @@
 #include <chrono>
 #include <functional>
 #include <string>
+#include <algorithm>
 #include <regex>
 
 using namespace std::chrono;
@@ -30,6 +31,8 @@ namespace uosm
 		constexpr float HOVERING_TOLERANCE(0.1f); // based on short term vio drift
 		constexpr float FLYING_TOLERANCE(0.1f);	  // based on short term vio drift
 		constexpr float HEADING_TOLERANCE(0.1f);  //  0.1 rad ~= 5.73 deg
+		constexpr float MAX_TURN_DEG(180.0f);
+		constexpr float MAX_MOVE_M(5.0f);  // per-command setpoint bound
 		constexpr float GOAL_TOLERANCE(0.5f);
 		constexpr float RAD2DEG(180 / M_PI);
 		constexpr float DEG2RAD(M_PI / 180);
@@ -214,6 +217,7 @@ namespace uosm
 					{
 						// Extract angle in degrees
 						float angle_deg = std::stof(line.substr(5, line.find(')') - 5));
+						angle_deg = std::clamp(angle_deg, -MAX_TURN_DEG, MAX_TURN_DEG);
 						// Convert to radians and update heading
 						float angle_rad = angle_deg * DEG2RAD;
 						current_heading += angle_rad;
@@ -228,6 +232,8 @@ namespace uosm
 					{
 						// Extract distance in meters
 						float distance = std::stof(line.substr(5, line.find(')') - 5));
+
+						distance = std::clamp(distance, -MAX_MOVE_M, MAX_MOVE_M);
 
 						// Update position based on current heading and distance
 						current_x += distance * cos(current_heading);


### PR DESCRIPTION
## Summary
LLM `Move(...)` / `Turn(...)` strings are applied with bare `stof` on success. A spuriously large value can command an extreme trajectory setpoint.

This change clamps **successful** parses to:
- Turn: ±180°
- Move: ±5 m

Both `px4_agent_nav_node` and `px4_agent_search_approach_node`.

## Why
Safety bound for agent-driven setpoints. Complements parse hardening; does not change arming/geo fences.

## Test plan
- [x] Diff-reviewed constants + std::clamp sites on both nodes
- [ ] SITL optional: feed `Move(999)` observes capped step

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
