### PR TITLE
fix: reject invalid home GPS before arming offboard

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -556,6 +556,17 @@ int main(int argc, char *argv[])
 		const float home_lon = node->vehicle_gp_.lon;
 		const float home_alt = node->vehicle_gp_.alt;
 
+		// Fail-closed if global position is missing or clearly unusable before arming.
+		if (!std::isfinite(home_lat) || !std::isfinite(home_lon) || !std::isfinite(home_alt) ||
+			(std::fabs(home_lat) < 1e-9f && std::fabs(home_lon) < 1e-9f))
+		{
+			RCLCPP_ERROR(
+				node->get_logger(),
+				"Invalid or missing home global position (lat=%.6f lon=%.6f alt=%.2f); aborting before arm/offboard",
+				home_lat, home_lon, home_alt);
+			return 1;
+		}
+
 		RCLCPP_WARN(node->get_logger(), "Pre-flight Check OK, home position: (lat = %.6f, lon = %.6f, alt = %.2f m)", home_lat, home_lon, home_alt);
 
 		// auto last_request = node->now();

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -543,6 +543,17 @@ int main(int argc, char *argv[])
 		const float home_lon = node->vehicle_gp_.lon;
 		const float home_alt = node->vehicle_gp_.alt;
 
+		// Fail-closed if global position is missing or clearly unusable before arming.
+		if (!std::isfinite(home_lat) || !std::isfinite(home_lon) || !std::isfinite(home_alt) ||
+			(std::fabs(home_lat) < 1e-9f && std::fabs(home_lon) < 1e-9f))
+		{
+			RCLCPP_ERROR(
+				node->get_logger(),
+				"Invalid or missing home global position (lat=%.6f lon=%.6f alt=%.2f); aborting before arm/offboard",
+				home_lat, home_lon, home_alt);
+			return 1;
+		}
+
 		RCLCPP_WARN(node->get_logger(), "Pre-flight Check OK, home position: (lat = %.6f, lon = %.6f, alt = %.2f m)", home_lat, home_lon, home_alt);
 
 		// auto last_request = node->now();


### PR DESCRIPTION
## Summary
Preflight can pass while `vehicle_global_position` is still zeroed or non-finite. We used to snapshot that as home and continue into offboard arming, which poisons later land lat/lon math.

This aborts with a clear error before the mission loop if lat/lon/alt are non-finite or still effectively (0,0).

## Changes
- Same guard in `px4_agent_nav_node.cpp` and `px4_agent_search_approach_node.cpp` after preflight, before arming.

## Test plan
- [ ] SITL/manual: with no GPS refill still fails closed instead of logging home 0,0 and arming
- [ ] Normal GPS path still logs preflight OK and enters OFFBOARD_ARMED

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
