### PR TITLE
fix: require non-empty mission_objective before init

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -68,6 +68,17 @@ namespace uosm
 				resend_command_ = get_parameter("resend_commnad").as_bool();
 				resend_size_ = get_parameter("resend_size").as_int();
 
+				// Require a non-empty mission objective before init (fail-closed)
+				{
+					const auto first = mission_objective_.find_first_not_of(" \t\r\n");
+					if (first == std::string::npos)
+					{
+						RCLCPP_ERROR(get_logger(), "mission_objective is required (empty or whitespace)");
+						is_init_ = false;
+						return;
+					}
+				}
+
 				// Publishers & Subscribers setup
 				const auto qos_profile = rclcpp::QoS(10)
 											 .reliability(rclcpp::ReliabilityPolicy::BestEffort)

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -69,6 +69,17 @@ namespace uosm
 				resend_command_ = get_parameter("resend_commnad").as_bool();
 				resend_size_ = get_parameter("resend_size").as_int();
 
+				// Require a non-empty mission objective before init (fail-closed)
+				{
+					const auto first = mission_objective_.find_first_not_of(" \t\r\n");
+					if (first == std::string::npos)
+					{
+						RCLCPP_ERROR(get_logger(), "mission_objective is required (empty or whitespace)");
+						is_init_ = false;
+						return;
+					}
+				}
+
 				// Publishers & Subscribers setup
 				const auto qos_profile = rclcpp::QoS(10)
 											 .reliability(rclcpp::ReliabilityPolicy::BestEffort)


### PR DESCRIPTION
## Summary
Both agent nodes could reach the flight loop with an empty default `mission_objective`, so VLN queries go out without a real task string.

After parameter load, empty/whitespace-only `mission_objective` now logs an error, sets `is_init_ = false`, and returns from the constructor so main never enters the mission loop.

## Motivation
Small fail-closed init gate next to existing goal-parse init failures on the search-approach path.

## Verification
- Constructor path review (nav + search_approach)
- pre-ship checklist #1–#11 clean (human author Bartok9)

AI-assisted scoping; human-reviewed before open.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
