### PR TITLE
fix: wrap heading error before FLYING to INTROSPECTION

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -617,9 +617,12 @@ int main(int argc, char *argv[])
 				if (node->is_vln_updated_)
 				{
 					const double dist = uosm::px4::computeEuclideanDistance(node->traj_, node->vehicle_lp_);
-					const double heading_diff = node->traj_.yaw - node->vehicle_lp_.heading;
+					// Shortest-angle yaw error on [-pi, pi] (signed subtraction can reject left turns)
+					const double heading_diff = std::atan2(
+						std::sin(node->traj_.yaw - node->vehicle_lp_.heading),
+						std::cos(node->traj_.yaw - node->vehicle_lp_.heading));
 
-					if (dist < uosm::px4::FLYING_TOLERANCE && heading_diff < uosm::px4::HEADING_TOLERANCE)
+					if (dist < uosm::px4::FLYING_TOLERANCE && std::fabs(heading_diff) < uosm::px4::HEADING_TOLERANCE)
 					{
 						// once vehicle reached traj location, start introspection
 						node->is_vln_updated_ = false;

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -604,10 +604,13 @@ int main(int argc, char *argv[])
 				if (node->is_vln_updated_)
 				{
 					const double dist = uosm::px4::computeEuclideanDistance(node->traj_, node->vehicle_lp_);
-					const double heading_diff = node->traj_.yaw - node->vehicle_lp_.heading;
+					// Shortest-angle yaw error on [-pi, pi]
+					const double heading_diff = std::atan2(
+						std::sin(node->traj_.yaw - node->vehicle_lp_.heading),
+						std::cos(node->traj_.yaw - node->vehicle_lp_.heading));
 					// RCLCPP_INFO(node->get_logger(), "dist = %.2f, heading_diff = %.2f", dist, heading_diff);
 
-					if (dist < uosm::px4::FLYING_TOLERANCE && std::abs(heading_diff) < uosm::px4::HEADING_TOLERANCE)
+					if (dist < uosm::px4::FLYING_TOLERANCE && std::fabs(heading_diff) < uosm::px4::HEADING_TOLERANCE)
 					{
 						// once vehicle reached traj location, start introspection
 						node->is_vln_updated_ = false;


### PR DESCRIPTION
## Summary
FLYING waits until distance and heading recurse the VLN setpoint before INTROSPECTION. Nav compared **signed** `yaw - heading` without abs (open #8 only touches nav). Neither path unwraps angles, so a −3.0 rad delta never passes a 0.1 rad tolerance even when true shortest error is small after wrap.

## Changes
- Both agent nodes: `heading_diff = atan2(sin(Δ), cos(Δ))` then `fabs(heading_diff) < HEADING_TOLERANCE`
- Complements #8 (abs-only on nav) with proper wrap on **both** nodes without depending on merge order of #8

## Motivation
Fail-closed progress for real headings near ±π without wetting arm/geofence logic.

## Verification
- [x] Diff limited to FLYING heading gate
- [x] pre-ship checklist trailers clean
- [ ] SITL optional

AI-assisted; human-reviewed.

Note: #8 is a partial fix (abs on nav only). This PR supersedes the intent with wrap+abs on both files; #8 can close as superseded if preferred.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
