### PR TITLE
fix: require local position validity flags before flight progress

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -49,6 +49,18 @@ namespace uosm
 			}
 		}
 
+		/** True when horizontal pose + heading are estimator-valid (PX4 VehicleLocalPosition flags). */
+		static inline bool localPositionReady2D(const px4_msgs::msg::VehicleLocalPosition &lp)
+		{
+			return lp.xy_valid && lp.heading_good_for_control;
+		}
+
+		/** True when 3D pose + heading are estimator-valid (needed for takeoff height checks). */
+		static inline bool localPositionReady3D(const px4_msgs::msg::VehicleLocalPosition &lp)
+		{
+			return lp.xy_valid && lp.z_valid && lp.heading_good_for_control;
+		}
+
 		class PX4AgentControl : public rclcpp::Node
 		{
 		public:
@@ -177,6 +189,15 @@ namespace uosm
 					vln_cmd_history_.push_back(trimmed_response);
 				}
 				is_vln_updated_ = true;
+
+				// Fail-closed: do not seed Move/Turn from invalid local position / heading
+				if (!localPositionReady2D(vehicle_lp_))
+				{
+					RCLCPP_WARN(get_logger(), "Ignoring VLN response: local position not valid (xy_valid=%d heading_good=%d)",
+								vehicle_lp_.xy_valid, vehicle_lp_.heading_good_for_control);
+					is_vln_updated_ = false;
+					return;
+				}
 
 				// Get current position and heading
 				float current_x = vehicle_lp_.x;
@@ -601,20 +622,24 @@ int main(int argc, char *argv[])
 			case STATE::HOVERING:
 			{
 				// RCLCPP_WARN(node->get_logger(), "STATE::HOVERING");
-				const double dist = uosm::px4::computeEuclideanDistance(node->traj_, node->vehicle_lp_, true);
-				if (dist < uosm::px4::HOVERING_TOLERANCE)
+				// Require estimator-valid 3D local pose before treating takeoff as complete
+				if (uosm::px4::localPositionReady3D(node->vehicle_lp_))
 				{
-					// once takeoff to sufficient height, start mission
-					node->is_vln_updated_ = false;
-					node->publish_vln_query();
-					state_ = STATE::FLYING;
+					const double dist = uosm::px4::computeEuclideanDistance(node->traj_, node->vehicle_lp_, true);
+					if (dist < uosm::px4::HOVERING_TOLERANCE)
+					{
+						// once takeoff to sufficient height, start mission
+						node->is_vln_updated_ = false;
+						node->publish_vln_query();
+						state_ = STATE::FLYING;
+					}
 				}
 				break;
 			}
 			case STATE::FLYING:
 			{
 				// RCLCPP_WARN(node->get_logger(), "STATE::FLYING");
-				if (node->is_vln_updated_)
+				if (node->is_vln_updated_ && uosm::px4::localPositionReady2D(node->vehicle_lp_))
 				{
 					const double dist = uosm::px4::computeEuclideanDistance(node->traj_, node->vehicle_lp_);
 					const double heading_diff = node->traj_.yaw - node->vehicle_lp_.heading;

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -50,6 +50,18 @@ namespace uosm
 			}
 		}
 
+		/** True when horizontal pose + heading are estimator-valid (PX4 VehicleLocalPosition flags). */
+		static inline bool localPositionReady2D(const px4_msgs::msg::VehicleLocalPosition &lp)
+		{
+			return lp.xy_valid && lp.heading_good_for_control;
+		}
+
+		/** True when 3D pose + heading are estimator-valid (needed for takeoff height checks). */
+		static inline bool localPositionReady3D(const px4_msgs::msg::VehicleLocalPosition &lp)
+		{
+			return lp.xy_valid && lp.z_valid && lp.heading_good_for_control;
+		}
+
 		class PX4AgentControl : public rclcpp::Node
 		{
 		public:
@@ -190,6 +202,15 @@ namespace uosm
 					vln_cmd_history_.push_back(trimmed_response);
 				}
 				is_vln_updated_ = true;
+
+				// Fail-closed: do not seed Move/Turn from invalid local position / heading
+				if (!localPositionReady2D(vehicle_lp_))
+				{
+					RCLCPP_WARN(get_logger(), "Ignoring VLN response: local position not valid (xy_valid=%d heading_good=%d)",
+								vehicle_lp_.xy_valid, vehicle_lp_.heading_good_for_control);
+					is_vln_updated_ = false;
+					return;
+				}
 
 				// Get current position and heading
 				float current_x = vehicle_lp_.x;
@@ -588,20 +609,24 @@ int main(int argc, char *argv[])
 			case STATE::HOVERING:
 			{
 				// RCLCPP_WARN(node->get_logger(), "STATE::HOVERING");
-				const double dist = uosm::px4::computeEuclideanDistance(node->traj_, node->vehicle_lp_, true);
-				if (dist < uosm::px4::HOVERING_TOLERANCE)
+				// Require estimator-valid 3D local pose before treating takeoff as complete
+				if (uosm::px4::localPositionReady3D(node->vehicle_lp_))
 				{
-					// once takeoff to sufficient height, start mission
-					node->is_vln_updated_ = false;
-					node->publish_vln_query();
-					state_ = STATE::FLYING;
+					const double dist = uosm::px4::computeEuclideanDistance(node->traj_, node->vehicle_lp_, true);
+					if (dist < uosm::px4::HOVERING_TOLERANCE)
+					{
+						// once takeoff to sufficient height, start mission
+						node->is_vln_updated_ = false;
+						node->publish_vln_query();
+						state_ = STATE::FLYING;
+					}
 				}
 				break;
 			}
 			case STATE::FLYING:
 			{
 				// RCLCPP_WARN(node->get_logger(), "STATE::FLYING");
-				if (node->is_vln_updated_)
+				if (node->is_vln_updated_ && uosm::px4::localPositionReady2D(node->vehicle_lp_))
 				{
 					const double dist = uosm::px4::computeEuclideanDistance(node->traj_, node->vehicle_lp_);
 					const double heading_diff = node->traj_.yaw - node->vehicle_lp_.heading;


### PR DESCRIPTION
## Summary

- Gate HOVERING takeoff-complete, FLYING reach checks, and VLN Move/Turn seeding on PX4 `VehicleLocalPosition` validity flags (`xy_valid`, `z_valid`, `heading_good_for_control`).
- Prevents stale zero/invalid local pose from advancing the offboard state machine or writing setpoints.

## Motivation

PX4 publishes local position fields before the estimator marks them valid. The nodes previously used `x/y/z/heading` without reading those flags, so pre-estimate zeros can look like “at setpoint” and skip real takeoff/hover waits, or seed VLN trajectories from invalid pose (complements finite-float hardening).

## Changes

Both `px4_agent_nav_node.cpp` and `px4_agent_search_approach_node.cpp`:

- `localPositionReady2D` / `localPositionReady3D` helpers
- HOVERING requires 3D-ready before distance gate
- FLYING reach requires 2D-ready
- `vln_response_cb` fails closed (clears `is_vln_updated_`) if not 2D-ready

## Verification

- Diff review both nodes; helpers only use flags already in `src/px4_msg/msg/VehicleLocalPosition.msg`
- Brace-balanced; no arm/geofence/API changes
- DCO Signed-off-by on commit

## Did NOT change

- Arm/disarm commands, geofence, altitude limits, land abort logic

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h

<!-- bartok-attribution -->
Claim: bartok
Operator: Bartok9
Campaign: aerial-drone
