### PR TITLE
fix: accept case-insensitive trimmed Yes from introspector

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -49,6 +49,44 @@ namespace uosm
 			}
 		}
 
+
+		/** True when introspector text is affirmative yes (trim, optional punct, case-insensitive). */
+		static inline bool isAffirmativeYes(std::string s)
+		{
+			// trim leading
+			const auto start = s.find_first_not_of(" \t\r\n");
+			if (start == std::string::npos)
+			{
+				return false;
+			}
+			s.erase(0, start);
+			// trim trailing
+			const auto end = s.find_last_not_of(" \t\r\n");
+			if (end != std::string::npos)
+			{
+				s.erase(end + 1);
+			}
+			// strip one trailing sentence punctuation common from VLMs
+			if (!s.empty())
+			{
+				const char c = s.back();
+				if (c == '.' || c == '!' || c == '?' || c == ';' || c == ':')
+				{
+					s.pop_back();
+				}
+			}
+			// trim again after punctuation strip
+			while (!s.empty() && (s.back() == ' ' || s.back() == '\t'))
+			{
+				s.pop_back();
+			}
+			for (char &ch : s)
+			{
+				ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+			}
+			return s == "yes";
+		}
+
 		class PX4AgentControl : public rclcpp::Node
 		{
 		public:
@@ -238,7 +276,7 @@ namespace uosm
 				introspector_response_ = *msg;
 				RCLCPP_INFO(get_logger(), "Introspector response: %s", introspector_response_.data.c_str());
 				is_introspection_updated_ = true;
-				if (introspector_response_.data == "Yes")
+				if (isAffirmativeYes(introspector_response_.data))
 				{
 					is_mission_done_ = true;
 				}

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -50,6 +50,44 @@ namespace uosm
 			}
 		}
 
+
+		/** True when introspector text is affirmative yes (trim, optional punct, case-insensitive). */
+		static inline bool isAffirmativeYes(std::string s)
+		{
+			// trim leading
+			const auto start = s.find_first_not_of(" \t\r\n");
+			if (start == std::string::npos)
+			{
+				return false;
+			}
+			s.erase(0, start);
+			// trim trailing
+			const auto end = s.find_last_not_of(" \t\r\n");
+			if (end != std::string::npos)
+			{
+				s.erase(end + 1);
+			}
+			// strip one trailing sentence punctuation common from VLMs
+			if (!s.empty())
+			{
+				const char c = s.back();
+				if (c == '.' || c == '!' || c == '?' || c == ';' || c == ':')
+				{
+					s.pop_back();
+				}
+			}
+			// trim again after punctuation strip
+			while (!s.empty() && (s.back() == ' ' || s.back() == '\t'))
+			{
+				s.pop_back();
+			}
+			for (char &ch : s)
+			{
+				ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+			}
+			return s == "yes";
+		}
+
 		class PX4AgentControl : public rclcpp::Node
 		{
 		public:
@@ -258,7 +296,7 @@ namespace uosm
 				is_introspection_updated_ = true;
 
 				// Update object detection status
-				if (introspector_response_.data == "Yes")
+				if (isAffirmativeYes(introspector_response_.data))
 				{
 					is_object_found_ = true;
 					RCLCPP_INFO(get_logger(), "Object detected - enabling movement commands");


### PR DESCRIPTION
## Summary

- Accept case-insensitive/trimmed VLM introspector answers equivalent to "Yes" (optional trailing punctuation).
- Keeps mission_done / object_found from stalling when Ollama returns `yes`, `YES`, ` Yes\n`, or `Yes.`.

## Motivation

Exact string equality to `"Yes"` is brittle against local VLMs. Nav never sets `is_mission_done_`; search never enables Move via `is_object_found_` — mission never lands / never approaches.

## Changes

Both control nodes:

- `isAffirmativeYes()` helper: trim · one trailing `.!?;:` · case-fold · compare to `"yes"`
- Replace `data == "Yes"` in both `introspector_response_cb` paths

## Verification

- Offline host unit of helper algorithm: 11 cases OK (`c++ -std=c++17`)
- Brace-balanced both cpp files; no arm/geofence changes
- DCO Signed-off-by on commit

## Did NOT change

- Arm/disarm, geofence, Move/Turn parsers, other FSM transitions

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h

<!-- bartok-attribution -->
Claim: bartok
Operator: Bartok9
Campaign: aerial-drone
