### PR TITLE
fix: guard VLN Move/Turn parse against missing closing paren

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -199,8 +199,14 @@ namespace uosm
 					// Parse Turn command
 					if (line.find("Turn(") == 0)
 					{
-						// Extract angle in degrees
-						float angle_deg = std::stof(line.substr(5, line.find(')') - 5));
+						// Extract angle in degrees (require closing ')' — npos would underflow substr length)
+						const auto close_paren = line.find(')');
+						if (close_paren == std::string::npos || close_paren <= 5)
+						{
+							RCLCPP_WARN(get_logger(), "Skipping malformed Turn command (missing closing paren): %s", line.c_str());
+							continue;
+						}
+						float angle_deg = std::stof(line.substr(5, close_paren - 5));
 						// Convert to radians and update heading
 						float angle_rad = angle_deg * DEG2RAD;
 						current_heading += angle_rad;
@@ -213,8 +219,14 @@ namespace uosm
 					// Parse Move command
 					else if (line.find("Move(") == 0)
 					{
-						// Extract distance in meters
-						float distance = std::stof(line.substr(5, line.find(')') - 5));
+						// Extract distance in meters (require closing ')' — npos would underflow substr length)
+						const auto close_paren = line.find(')');
+						if (close_paren == std::string::npos || close_paren <= 5)
+						{
+							RCLCPP_WARN(get_logger(), "Skipping malformed Move command (missing closing paren): %s", line.c_str());
+							continue;
+						}
+						float distance = std::stof(line.substr(5, close_paren - 5));
 
 						// Update position based on current heading and distance
 						current_x += distance * cos(current_heading);

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -212,8 +212,14 @@ namespace uosm
 					// Parse Turn command - always process turn commands regardless of object detection
 					if (line.find("Turn(") == 0)
 					{
-						// Extract angle in degrees
-						float angle_deg = std::stof(line.substr(5, line.find(')') - 5));
+						// Extract angle in degrees (require closing ')' — npos would underflow substr length)
+						const auto close_paren = line.find(')');
+						if (close_paren == std::string::npos || close_paren <= 5)
+						{
+							RCLCPP_WARN(get_logger(), "Skipping malformed Turn command (missing closing paren): %s", line.c_str());
+							continue;
+						}
+						float angle_deg = std::stof(line.substr(5, close_paren - 5));
 						// Convert to radians and update heading
 						float angle_rad = angle_deg * DEG2RAD;
 						current_heading += angle_rad;
@@ -226,8 +232,14 @@ namespace uosm
 					// Parse Move command - only process if object is found
 					else if (line.find("Move(") == 0 && is_object_found_)
 					{
-						// Extract distance in meters
-						float distance = std::stof(line.substr(5, line.find(')') - 5));
+						// Extract distance in meters (require closing ')' — npos would underflow substr length)
+						const auto close_paren = line.find(')');
+						if (close_paren == std::string::npos || close_paren <= 5)
+						{
+							RCLCPP_WARN(get_logger(), "Skipping malformed Move command (missing closing paren): %s", line.c_str());
+							continue;
+						}
+						float distance = std::stof(line.substr(5, close_paren - 5));
 
 						// Update position based on current heading and distance
 						current_x += distance * cos(current_heading);


### PR DESCRIPTION
## Summary
Bad LLM/VLN lines without a closing `)` made `line.find(')')` return `npos`. Subtracting 5 underflowed the `substr` length and could crash the control nodes.

Both `px4_agent_nav_node` and `px4_agent_search_approach_node` now require a valid closing paren (and non-empty payload) before `std::stof`, and skip the line with a warning otherwise.

## Test plan
- [ ] Well-formed `Turn(90)` / `Move(1.5)` still parse
- [ ] `Turn(90` / `Move(` log skip and leave trajectory unchanged for that line
- [ ] SITL smoke optional (paper stack)

AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->