### PR TITLE
fix: reject non-finite local pose before VLN trajectory parse

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -16,6 +16,7 @@
 #include <chrono>
 #include <functional>
 #include <string>
+#include <cmath>
 #include <regex>
 
 using namespace std::chrono;
@@ -178,10 +179,17 @@ namespace uosm
 				}
 				is_vln_updated_ = true;
 
-				// Get current position and heading
+				// Get current position and heading (reject non-finite LP before VLN integration)
 				float current_x = vehicle_lp_.x;
 				float current_y = vehicle_lp_.y;
 				float current_heading = vehicle_lp_.heading;
+				if (!std::isfinite(current_x) || !std::isfinite(current_y) || !std::isfinite(current_heading))
+				{
+					RCLCPP_ERROR(get_logger(),
+								 "Skipping VLN trajectory update: non-finite local pose (x=%.3f y=%.3f heading=%.3f)",
+								 current_x, current_y, current_heading);
+					return;
+				}
 
 				// Parse the response string line by line
 				std::istringstream response_stream(vln_response_.data);

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -16,6 +16,7 @@
 #include <chrono>
 #include <functional>
 #include <string>
+#include <cmath>
 #include <regex>
 
 using namespace std::chrono;
@@ -191,10 +192,17 @@ namespace uosm
 				}
 				is_vln_updated_ = true;
 
-				// Get current position and heading
+				// Get current position and heading (reject non-finite LP before VLN integration)
 				float current_x = vehicle_lp_.x;
 				float current_y = vehicle_lp_.y;
 				float current_heading = vehicle_lp_.heading;
+				if (!std::isfinite(current_x) || !std::isfinite(current_y) || !std::isfinite(current_heading))
+				{
+					RCLCPP_ERROR(get_logger(),
+								 "Skipping VLN trajectory update: non-finite local pose (x=%.3f y=%.3f heading=%.3f)",
+								 current_x, current_y, current_heading);
+					return;
+				}
 
 				// Parse the response string line by line
 				std::istringstream response_stream(vln_response_.data);


### PR DESCRIPTION
## Summary
VLN callbacks seed trajectory integration from `VehicleLocalPosition` x/y/heading without checking finiteness. A NaN heading or pose poisons `cos`/`sin` updates and offboard setpoints.

Early-return with an error log when any seed component is non-finite, in both agent nodes. Includes `<cmath>`.

## Test plan
- [ ] Finite pose: VLN still updates trajectory
- [ ] Inject NaN heading in unit/SITL stub → skip update, no crash
- [ ] Orthogonal to existing LP validity-flag hardening PRs

AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->