### PR TITLE
fix: skip non-finite trajectory setpoint publishes

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -301,6 +301,16 @@ namespace uosm
 		 */
 		void PX4AgentControl::publish_trajectory_setpoint()
 		{
+			if (!std::isfinite(traj_.position[0]) ||
+				!std::isfinite(traj_.position[1]) ||
+				!std::isfinite(traj_.position[2]) ||
+				!std::isfinite(traj_.yaw))
+			{
+				RCLCPP_WARN(get_logger(),
+							 "Skipping non-finite trajectory setpoint (x=%.3f y=%.3f z=%.3f yaw=%.3f)",
+							 traj_.position[0], traj_.position[1], traj_.position[2], traj_.yaw);
+				return;
+			}
 			traj_.timestamp = get_clock()->now().nanoseconds() / 1000;
 			trajectory_setpoint_pub_->publish(traj_);
 			// RCLCPP_DEBUG(get_logger(), "Setting Trajectory (x = %.2f m, y = %.2f m, z = %.2f m, yaw = %.2f rad)", traj_.position[0], traj_.position[1], traj_.position[2], traj_.yaw);

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -327,6 +327,16 @@ namespace uosm
 		 */
 		void PX4AgentControl::publish_trajectory_setpoint()
 		{
+			if (!std::isfinite(traj_.position[0]) ||
+				!std::isfinite(traj_.position[1]) ||
+				!std::isfinite(traj_.position[2]) ||
+				!std::isfinite(traj_.yaw))
+			{
+				RCLCPP_WARN(get_logger(),
+							 "Skipping non-finite trajectory setpoint (x=%.3f y=%.3f z=%.3f yaw=%.3f)",
+							 traj_.position[0], traj_.position[1], traj_.position[2], traj_.yaw);
+				return;
+			}
 			traj_.timestamp = get_clock()->now().nanoseconds() / 1000;
 			trajectory_setpoint_pub_->publish(traj_);
 			// RCLCPP_DEBUG(get_logger(), "Setting Trajectory (x = %.2f m, y = %.2f m, z = %.2f m, yaw = %.2f rad)", traj_.position[0], traj_.position[1], traj_.position[2], traj_.yaw);


### PR DESCRIPTION
## Summary

- Gate `publish_trajectory_setpoint()` so non-finite `traj_.position[0..2]` or `traj_.yaw` is never published to PX4.
- Identical fail-closed WARN+return in nav and search-approach nodes; finite path unchanged.

## Motivation

The mission loop publishes setpoints every tick (~20 Hz). If VLN/partial write or estimator glitches leave NaN/Inf in `traj_`, PX4 can receive invalid offboard setpoints (undefined control behavior / possible mode dropout). This is defense-in-depth on the publish edge; complementary to open #18 which rejects non-finite local pose before writing trajectory from VLN.

## Verification

- Code review: both `px4_agent_nav_node.cpp` and `px4_agent_search_approach_node.cpp` gate all four floats before timestamp/publish
- Finite path still sets timestamp and publishes exactly once
- Did NOT change: arm APIs, geofence, altitude limits, offboard control-mode heartbeat, land/disarm detection, distance helper

## Agent

AI-assisted micro-diff; human-reviewed before push.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h

<!-- bartok-attribution -->
Claim: bartok
Operator: Bartok9
Campaign: aerial-drone
