### PR TITLE
fix: refuse non-finite coords/yaw on NAV_LAND command

### DIFF
--- a/src/px4_agent_control/src/px4_agent_nav_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_nav_node.cpp
@@ -17,6 +17,7 @@
 #include <functional>
 #include <string>
 #include <regex>
+#include <cmath>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
@@ -309,6 +310,21 @@ namespace uosm
 		void PX4AgentControl::request_landing(float lat, float lon, float alt)
 		{
 			// https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LAND
+			if (!std::isfinite(lat) || !std::isfinite(lon) || !std::isfinite(alt))
+			{
+				RCLCPP_ERROR(get_logger(), "request_landing: refusing non-finite lat/lon/alt (%.6f, %.6f, %.2f)", lat, lon, alt);
+				return;
+			}
+			float land_yaw = traj_.yaw;
+			if (!std::isfinite(land_yaw))
+			{
+				land_yaw = vehicle_lp_.heading;
+			}
+			if (!std::isfinite(land_yaw))
+			{
+				RCLCPP_WARN(get_logger(), "request_landing: non-finite traj/vehicle yaw; using 0 rad");
+				land_yaw = 0.0f;
+			}
 			auto request = std::make_shared<px4_msgs::srv::VehicleCommand::Request>();
 
 			VehicleCommand msg{};
@@ -317,7 +333,7 @@ namespace uosm
 			msg.param2 = 0.0f; // Land Mode
 			// https://docs.px4.io/main/en/advanced_config/parameter_reference.html#MPC_LAND_SPEED
 			msg.param3 = NAN;		// empty
-			msg.param4 = traj_.yaw; // Yaw (rad)
+			msg.param4 = land_yaw; // Yaw (rad) — finite only
 			msg.param5 = lat;		// lat
 			msg.param6 = lon;		// lon
 			msg.param7 = alt;		// alt (m)

--- a/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
+++ b/src/px4_agent_control/src/px4_agent_search_approach_node.cpp
@@ -17,6 +17,7 @@
 #include <functional>
 #include <string>
 #include <regex>
+#include <cmath>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
@@ -335,6 +336,21 @@ namespace uosm
 		void PX4AgentControl::request_landing(float lat, float lon, float alt)
 		{
 			// https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LAND
+			if (!std::isfinite(lat) || !std::isfinite(lon) || !std::isfinite(alt))
+			{
+				RCLCPP_ERROR(get_logger(), "request_landing: refusing non-finite lat/lon/alt (%.6f, %.6f, %.2f)", lat, lon, alt);
+				return;
+			}
+			float land_yaw = traj_.yaw;
+			if (!std::isfinite(land_yaw))
+			{
+				land_yaw = vehicle_lp_.heading;
+			}
+			if (!std::isfinite(land_yaw))
+			{
+				RCLCPP_WARN(get_logger(), "request_landing: non-finite traj/vehicle yaw; using 0 rad");
+				land_yaw = 0.0f;
+			}
 			auto request = std::make_shared<px4_msgs::srv::VehicleCommand::Request>();
 
 			VehicleCommand msg{};
@@ -343,7 +359,7 @@ namespace uosm
 			msg.param2 = 0.0f; // Land Mode
 			// https://docs.px4.io/main/en/advanced_config/parameter_reference.html#MPC_LAND_SPEED
 			msg.param3 = NAN;		// empty
-			msg.param4 = traj_.yaw; // Yaw (rad)
+			msg.param4 = land_yaw; // Yaw (rad) — finite only
 			msg.param5 = lat;		// lat
 			msg.param6 = lon;		// lon
 			msg.param7 = alt;		// alt (m)


### PR DESCRIPTION
## Summary

- Gate `request_landing()` so non-finite latitude, longitude, or altitude never sends `VEHICLE_CMD_NAV_LAND`.
- Coach land yaw from finite `traj_.yaw`, else finite local-position heading, else `0` with a warning — applies in both nav and search-approach nodes.

## Motivation

Open barricades on trajectory *publish* (#25) do not cover auto-land vehicle commands. A NaN yaw or bad geo fix on the land path can still reach PX4 via the command client. This keeps the land edge fail-closed without changing abort altitude, land mode, or arming.

Orthogonal to finite LP/VLN work already open; intentional single new PR tonight under px4-family maxNew=1.

## Verification

- Diff review: both control nodes share the same guard order (coords → yaw fallback → build message)
- Finite path still sets param1–7 and async_sends the land request
- Did **not** change: arm APIs, geofence, altitude limits, offboard mode heartbeat, distance helper, setpoint publish path

## Agent

AI-assisted; human-reviewed before push. Spec: `specs/ros2-px4-agent-ws/2026-07-24-1.md`.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
